### PR TITLE
replace float64 with inexact-num

### DIFF
--- a/base.elv
+++ b/base.elv
@@ -67,28 +67,28 @@ var tests = [base.elv
   'These functions largely assume numbers, lists, and strings.  The list operations are of dubious usefulness for users, however.'
   '# Math functions'
   [is-zero
-   'works with text, nums, and floats'
+   'works with text, nums, and inexact-nums'
    (test:assert-one $true)
    { is-zero 0 }
    { is-zero (num 0) }
-   { is-zero (float64 0) }
+   { is-zero (inexact-num 0) }
 
    (test:assert-one $false)
    { is-zero 1 }
    { is-zero (randint 1 100) }
-   { is-zero (float64 (randint 1 100)) }]
+   { is-zero (inexact-num (randint 1 100)) }]
 
   [is-one
-   'works with text, nums, and floats'
+   'works with text, nums, and inexact-nums'
    (test:assert-one $true)
    { is-one 1 }
    { is-one (num 1) }
-   { is-one (float64 1) }
+   { is-one (inexact-num 1) }
 
    (test:assert-one $false)
    { is-one 0 }
    { is-one (num 0)}
-   { is-one (float64 0)}]
+   { is-one (inexact-num 0)}]
 
   [evens
    'only works with strings & nums'
@@ -96,7 +96,7 @@ var tests = [base.elv
    { range -5 6 | each $is-even~ }
    { range -5 6 | each $to-string~ | each $is-even~ }
 
-   'fails with floats'
+   'fails with inexact-nums'
    (test:assert-error)
    { is-even 5.0 }]
 
@@ -106,12 +106,12 @@ var tests = [base.elv
    { range -5 6 | each $is-odd~ }
    { range -5 6 | each $to-string~ | each $is-odd~ }
 
-   'fails with floats'
+   'fails with inexact-nums'
    (test:assert-error)
    { is-odd 5.0 }]
 
   [inc
-   'works with text, nums, and floats'
+   'works with text, nums, and inexact-nums'
    (test:assert-each (range -4 7))
    { range -5 6 | each $inc~ }
 
@@ -119,10 +119,10 @@ var tests = [base.elv
    { range -5 6 | each $to-string~ | each $inc~ }
 
    (test:assert-each (range -4.0 7))
-   { range -5 6 | each $float64~ | each $inc~ }]
+   { range -5 6 | each $inexact-num~ | each $inc~ }]
 
   [dec
-   'works with text, nums, and floats'
+   'works with text, nums, and inexact-nums'
    (test:assert-each (range -6 5))
    { range -5 6 | each $dec~ }
 
@@ -130,17 +130,17 @@ var tests = [base.elv
    { range -5 6 | each $to-string~ | each $dec~ }
 
    (test:assert-each (range -6.0 5))
-   { range -5 6 | each $float64~ | each $dec~ }]
+   { range -5 6 | each $inexact-num~ | each $dec~ }]
 
   [pos/neg
-   'works with text, nums, and floats'
+   'works with text, nums, and inexact-nums'
    (test:assert-each $false $true)
    { each $pos~ [-1 1] }
    { each $neg~ [1 -1] }
    { each $pos~ [(num -1) (num 1)] }
    { each $neg~ [(num 1) (num -1)] }
-   { each $pos~ [(float64 -1) (float64 1)] }
-   { each $neg~ [(float64 1) (float64 -1)] }]
+   { each $pos~ [(inexact-num -1) (inexact-num 1)] }
+   { each $neg~ [(inexact-num 1) (inexact-num -1)] }]
 
   '# Type predicates'
 

--- a/base.org
+++ b/base.org
@@ -107,28 +107,28 @@ More complicated list operations.
     'These functions largely assume numbers, lists, and strings.  The list operations are of dubious usefulness for users, however.'
     '# Math functions'
     [is-zero
-     'works with text, nums, and floats'
+     'works with text, nums, and inexact-nums'
      (test:assert-one $true)
      { is-zero 0 }
      { is-zero (num 0) }
-     { is-zero (float64 0) }
+     { is-zero (inexact-num 0) }
 
      (test:assert-one $false)
      { is-zero 1 }
      { is-zero (randint 1 100) }
-     { is-zero (float64 (randint 1 100)) }]
+     { is-zero (inexact-num (randint 1 100)) }]
 
     [is-one
-     'works with text, nums, and floats'
+     'works with text, nums, and inexact-nums'
      (test:assert-one $true)
      { is-one 1 }
      { is-one (num 1) }
-     { is-one (float64 1) }
+     { is-one (inexact-num 1) }
 
      (test:assert-one $false)
      { is-one 0 }
      { is-one (num 0)}
-     { is-one (float64 0)}]
+     { is-one (inexact-num 0)}]
 
     [evens
      'only works with strings & nums'
@@ -136,7 +136,7 @@ More complicated list operations.
      { range -5 6 | each $is-even~ }
      { range -5 6 | each $to-string~ | each $is-even~ }
 
-     'fails with floats'
+     'fails with inexact-nums'
      (test:assert-error)
      { is-even 5.0 }]
 
@@ -146,12 +146,12 @@ More complicated list operations.
      { range -5 6 | each $is-odd~ }
      { range -5 6 | each $to-string~ | each $is-odd~ }
 
-     'fails with floats'
+     'fails with inexact-nums'
      (test:assert-error)
      { is-odd 5.0 }]
 
     [inc
-     'works with text, nums, and floats'
+     'works with text, nums, and inexact-nums'
      (test:assert-each (range -4 7))
      { range -5 6 | each $inc~ }
 
@@ -159,10 +159,10 @@ More complicated list operations.
      { range -5 6 | each $to-string~ | each $inc~ }
 
      (test:assert-each (range -4.0 7))
-     { range -5 6 | each $float64~ | each $inc~ }]
+     { range -5 6 | each $inexact-num~ | each $inc~ }]
 
     [dec
-     'works with text, nums, and floats'
+     'works with text, nums, and inexact-nums'
      (test:assert-each (range -6 5))
      { range -5 6 | each $dec~ }
 
@@ -170,17 +170,17 @@ More complicated list operations.
      { range -5 6 | each $to-string~ | each $dec~ }
 
      (test:assert-each (range -6.0 5))
-     { range -5 6 | each $float64~ | each $dec~ }]
+     { range -5 6 | each $inexact-num~ | each $dec~ }]
 
     [pos/neg
-     'works with text, nums, and floats'
+     'works with text, nums, and inexact-nums'
      (test:assert-each $false $true)
      { each $pos~ [-1 1] }
      { each $neg~ [1 -1] }
      { each $pos~ [(num -1) (num 1)] }
      { each $neg~ [(num 1) (num -1)] }
-     { each $pos~ [(float64 -1) (float64 1)] }
-     { each $neg~ [(float64 1) (float64 -1)] }]
+     { each $pos~ [(inexact-num -1) (inexact-num 1)] }
+     { each $neg~ [(inexact-num 1) (inexact-num -1)] }]
 
     '# Type predicates'
 

--- a/test.elv
+++ b/test.elv
@@ -663,9 +663,9 @@ var tests = [Test.elv
    { (assert-coll)[f] { put [a b c] } | put (one)[bool] }
    { (assert-coll)[f] { put [&foo=bar] } | put (one)[bool] }
 
-   '`assert-num` works on nums & floats.  It could expand to more types if elvish adds more in the future.'
+   '`assert-num` works on nums & inexact-nums.  It could expand to more types if elvish adds more in the future.'
    { (assert-num)[f] { num 1 } | put (one)[bool] }
-   { (assert-num)[f] { float64 1 } | put (one)[bool] }
+   { (assert-num)[f] { inexact-num 1 } | put (one)[bool] }
 
    '`assert-ok` does not exist (yet), but you can get it with this.  In this example `{ put foo }` is the function we are testing for success.  We do not care about the return value - only that the function works without error'
    { (assert-one $ok)[f] { var @_ = (var err = ?({ put foo })); put $err } | put (one)[bool] }

--- a/test.org
+++ b/test.org
@@ -758,9 +758,9 @@ Tests for this module
      { (assert-coll)[f] { put [a b c] } | put (one)[bool] }
      { (assert-coll)[f] { put [&foo=bar] } | put (one)[bool] }
 
-     '`assert-num` works on nums & floats.  It could expand to more types if elvish adds more in the future.'
+     '`assert-num` works on nums & inexact-nums.  It could expand to more types if elvish adds more in the future.'
      { (assert-num)[f] { num 1 } | put (one)[bool] }
-     { (assert-num)[f] { float64 1 } | put (one)[bool] }
+     { (assert-num)[f] { inexact-num 1 } | put (one)[bool] }
 
      '`assert-ok` does not exist (yet), but you can get it with this.  In this example `{ put foo }` is the function we are testing for success.  We do not care about the return value - only that the function works without error'
      { (assert-one $ok)[f] { var @_ = (var err = ?({ put foo })); put $err } | put (one)[bool] }


### PR DESCRIPTION
elvish v0.19 explicitely deprecated the 'float64' which has been deprecated since v0.16 but was never marked as such.  These changes get rid of the warnings.